### PR TITLE
Allow specifying a class blacklist, and only enable for non-blacklisted objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Leaflet plugin to favor double-click events over single-click events.
 to zoom the map but happen to hit a marker you will get a popup instead of a zoom.
 
 This plugin allows enabling the reverse behavior where double-click events are favored over single-click events.
+
+Try the [demo](http://azavea.github.io/Leaflet.favorDoubleClick).

--- a/example/index.html
+++ b/example/index.html
@@ -10,19 +10,15 @@
         <![endif]-->
 </head>
 <body>
-    <div id="map" style="width: 600px; height: 400px; float: left; margin-right: 40px"></div>
-    <div style="font: 16pt sans-serif; margin-left: 600px">
-        <p><br/>1) Double-click to zoom the map, but hit the circle by mistake.<br/>With default Leaflet behavior, three events are handled:
-            <ul style="margin-left: 50px;">
-                <li>Click (on circle)&mdash;briefly raises popup "I am a circle".</li>
-                <li>Double-click (on map)&mdash;zooms in.</li>
-                <li>Click (on map)&mdash;raises popup "You clicked the map at ...".</li>
-            </ul>
-        </p>
+    <div id="map" style="width: 600px; height: 400px; float: left"></div>
+    <div style="font: 16pt sans-serif; margin-left: 620px">
+        <p>&nbsp;</p>
+        <p>1) Double-click to zoom the map, but hit the circle by mistake. You get two unwanted popups (one just briefly).</p>
         <p>2) Close the popup and zoom back out.
-        <p>3) Click this checkbox to enable the plugin:</p>
-        <p style="padding-left: 60px"><label><input type="checkbox" onclick="enablePlugin(this.checked)"> Favor double-click</label></p>
-        <p>4) Try again&mdash;double-click the circle, intending to zoom the map. You zoom in as desired.</p>
+        <p>3) <label><input type="checkbox" onclick="enablePlugin(this.checked)"> Click here to enable the plugin.</label></p>
+        <p>4) Try again&mdash;double-click to zoom the map, but hit the circle by mistake. You zoom in as desired.</p>
+        <p>5) Click on the circle. There is a short delay before the popup appears&mdash;that's the price of favoring double-click.</p>
+        <p>6) Close the popup and zoom back out. There is no delay for these clicks, because of the plugin's default blacklist.</p>
     </div>
 
     <script src="leaflet_0.8-dev-src.js"></script>

--- a/src/L.favorDoubleClick.js
+++ b/src/L.favorDoubleClick.js
@@ -1,11 +1,17 @@
 (function (L) {
     var _isEnabled = false,
-        _delay = 200;
+        _delay = 200,
+        _blacklist = [L.Control, L.Popup];
 
     L.favorDoubleClick = {
-        enable: function (delay) {
+        getDelay: function () { return _delay; }, 
+        setDelay: function (delay) { _delay = delay; }, 
+
+        getBlacklist: function () { return _blacklist; }, 
+        setBlacklist: function (blacklist) { _blacklist = blacklist; },
+
+        enable: function () {
             _isEnabled = true;
-            _delay = delay || _delay;
         },
 
         disable: function () {
@@ -42,7 +48,7 @@
 
         return function (event) {
             var context = this;
-            if (!_isEnabled) {
+            if (!shouldFavorDoubleClick(context)) {
                 clickHandler.call(context, event);
             } else {
                 clickCount++;
@@ -60,6 +66,21 @@
                 }
             }
         };
+    }
+
+    function shouldFavorDoubleClick(obj) {
+        return _isEnabled && !isKindOf(obj, _blacklist);
+    }
+
+    function isKindOf(obj, types) {
+        if (types) {
+            for (var i = 0, len = types.length; i < len; i++) {
+                if (obj instanceof types[i]) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     install();


### PR DESCRIPTION
- The cost of favoring double-click is a short delay when handling click. For some objects on the map that's annoying and uneccesary, like zoom buttons and popup close buttons. Allow specifying a "blacklist" of Leaflet classes for which "favor double-click" won't apply.
- The default blacklist includes `L.Popup` and `L.Control` (which represents e.g. buttons on the map).
- Add functions to get and set the blacklist and the delay, rather than specifying them on `enable`.
- Update demo to discuss this delay.
