### PR TITLE
Feature/lol/adjust function usage

### DIFF
--- a/src/L.favorDoubleClick.js
+++ b/src/L.favorDoubleClick.js
@@ -4,10 +4,10 @@
         _blacklist = [L.Control, L.Popup];
 
     L.favorDoubleClick = {
-        getDelay: function () { return _delay; }, 
-        setDelay: function (delay) { _delay = delay; }, 
+        getDelay: function () { return _delay; },
+        setDelay: function (delay) { _delay = delay; },
 
-        getBlacklist: function () { return _blacklist; }, 
+        getBlacklist: function () { return _blacklist; },
         setBlacklist: function (blacklist) { _blacklist = blacklist; },
 
         enable: function () {

--- a/src/L.favorDoubleClick.js
+++ b/src/L.favorDoubleClick.js
@@ -59,14 +59,12 @@
                     clearTimeout(timeoutId);
                 }
                 L.DomEvent.stopPropagation(event);
-                timeoutId = setTimeout(onClicksFinished, _delay);
-
-                function onClicksFinished() {
+                timeoutId = setTimeout(function onClicksFinished() {
                     if (clickCount === 1) {
                         clickHandler.call(context, event);
                     }
                     clickCount = 0;
-                }
+                }, _delay);
             }
         };
     }


### PR DESCRIPTION
### Replace named function with anonymous function.
    
    In some cases defining a named function in a block results in errors. I found
    this while shimming this plugin into Leaflet using browserify and testing on
    Firefox. The same functionality can be achieved with an anonymous function
    which avoids such problems.